### PR TITLE
Added setter and getter for inverterAddress

### DIFF
--- a/Aurora.cpp
+++ b/Aurora.cpp
@@ -75,6 +75,14 @@ void Aurora::begin(){
 #endif
 }
 
+void Aurora::setInverterAddress(byte inverterAddress) {
+    this->inverterAddress = inverterAddress;
+}
+
+byte Aurora::getInverterAddress() {
+    return this->inverterAddress;
+}
+
 void Aurora::clearData(byte *data, byte len) {
     for (int i = 0; i < len; i++) {
         data[i] = 0;

--- a/Aurora.h
+++ b/Aurora.h
@@ -101,6 +101,9 @@ class Aurora {
 
         void begin();
 
+        void setInverterAddress(byte);
+        byte getInverterAddress();
+
         void clearReceiveData();
 
         typedef struct {


### PR DESCRIPTION
Setting inverterAddress runtime permit to manage multiple inverters with a single Aurora instance